### PR TITLE
Added autoinstallers

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,6 +28,14 @@
 
 ## Installation
 
+For a quick installation just pipe the `install.sh` script to sh as follows:
+
+```bash
+curl -O https://raw.githubusercontent.com/africanmx/muccadoro/master/install.sh | sh
+```
+
+If it asks for your sudo password it is because it is installing it in a binary directory.
+
 Put `muccadoro` inside some directory in your `PATH`, e.g. `~/bin/` (or `~/.local/bin/`):
 
 ```bash

--- a/README.md
+++ b/README.md
@@ -36,6 +36,10 @@ curl -O https://raw.githubusercontent.com/africanmx/muccadoro/master/install.sh 
 
 If it asks for your sudo password it is because it is installing it in a binary directory.
 
+By now, you should have muccadoro installed and no other step is required.
+
+### As an alternate version you can follow these steps:
+
 Put `muccadoro` inside some directory in your `PATH`, e.g. `~/bin/` (or `~/.local/bin/`):
 
 ```bash

--- a/README.md
+++ b/README.md
@@ -38,7 +38,7 @@ If it asks for your sudo password it is because it is installing it in a binary 
 
 By now, you should have muccadoro installed and no other step is required.
 
-### As an alternate version you can follow these steps:
+### As an alternate method you can follow these steps:
 
 Put `muccadoro` inside some directory in your `PATH`, e.g. `~/bin/` (or `~/.local/bin/`):
 

--- a/install.sh
+++ b/install.sh
@@ -1,0 +1,57 @@
+#!/bin/bash
+MUCCADORO_URL="https://raw.githubusercontent.com/meribold/muccadoro/master/muccadoro"
+detect_package_manager(){
+        case "$SHELL" in
+                *termux*) echo apt && return; ;;
+                *) ;;
+        esac
+        test -f /etc/debian_version && echo apt && return
+        test -f /etc/redhat-release && echo yum && return
+        test -f /etc/arch-release && echo pacman && return
+        test -f /etc/gentoo-release && echo emerge && return
+        test -f /etc/SuSE-release && echo zypp && return
+}
+
+try_to_install(){
+	test -n "$(which $1)" && echo "$1 OK" && return
+        package_manager="$(detect_package_manager)"
+        case "$package_manager" in
+                apt)
+                        test -x "$(command -v sudo)" && sudo apt update || apt update
+                        test -x "$(command -v sudo)" && sudo apt -y install "$1" || apt -y install "$1"
+                ;;
+                yum)
+                        test -x "$(command -v sudo)" && sudo yum update || yum update
+                        test -x "$(command -v sudo)" && sudo yum -y install "$1" || yum -y install "$1"
+                ;;
+                pacman)
+                        pacman -Su
+                        yes | pacman -S -y "$1"
+                ;;
+                emerge)
+                        echo "Program $1 unavailable for Gentoo install" >&2
+                        exit 127
+                ;;
+                zypp)
+                        echo "Program $1 unavailable for Suse install" >&2
+                        exit 127
+                ;;
+        esac
+}
+
+installer(){
+	echo "Running..."
+	try_to_install curl
+	test -d ~/../usr/bin && place=~/../usr/bin # this is for termux
+	test -z "$place" && test -d /usr/bin && place=/usr/bin
+	test -z "$place" && test -d /bin && place=/bin
+	test -z "$place" && echo "No place to install. Sorry" >&2 && exit 1
+	(
+		cd "$place"
+		test -x "$(command -v sudo)" && sudo curl -O "$MUCCADORO_URL" >/dev/null 2>&1 || curl -O "$MUCCADORO_URL" >/dev/null 2>&1
+		test -x "$(command -v sudo)" && sudo chmod +x muccadoro || chmod +x muccadoro
+		test -n "$(which muccadoro)" && echo "Done!" || echo "Failed. Try with sudo" >&2
+	)
+	exit
+}
+installer

--- a/install.sh
+++ b/install.sh
@@ -50,7 +50,7 @@ installer(){
 		cd "$place"
 		test -x "$(command -v sudo)" && sudo curl -O "$MUCCADORO_URL" >/dev/null 2>&1 || curl -O "$MUCCADORO_URL" >/dev/null 2>&1
 		test -x "$(command -v sudo)" && sudo chmod +x muccadoro || chmod +x muccadoro
-		test -n "$(which muccadoro)" && echo "Done!" || echo "Failed. Try with sudo" >&2
+		test -n "$(which muccadoro)" && echo "Done! You have muccadoro installed now." || echo "Failed. Try with sudo" >&2
 	)
 	exit
 }

--- a/install.sh
+++ b/install.sh
@@ -13,6 +13,13 @@ detect_package_manager(){
 }
 
 try_to_install(){
+	case "$PATH" in
+		*WINDOWS*)
+			echo "Installer unimplemented for Windows"
+			exit
+		;;
+		*) ;;
+	esac
 	test -n "$(which $1)" && echo "$1 OK" && return
         package_manager="$(detect_package_manager)"
         case "$package_manager" in

--- a/install.sh
+++ b/install.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-MUCCADORO_URL="https://raw.githubusercontent.com/meribold/muccadoro/master/muccadoro"
+MUCCADORO_URL="https://raw.githubusercontent.com/africanmx/muccadoro/master/muccadoro"
 detect_package_manager(){
         case "$SHELL" in
                 *termux*) echo apt && return; ;;

--- a/muccadoro
+++ b/muccadoro
@@ -20,6 +20,13 @@ detect_package_manager(){
 
 try_to_install(){
 	package_manager="$(detect_package_manager)"
+	case "$PATH" in
+		*WINDOWS*)
+			echo "Please install program $1 for Windows first"
+			exit 127
+		;;
+		*) ;;
+	esac
 	case "$package_manager" in
 		apt)
 			test -x "$(command -v sudo)" && sudo apt update || apt update

--- a/muccadoro
+++ b/muccadoro
@@ -5,10 +5,44 @@ set -o nounset -o pipefail
 # Before doing anything, check if the required programs are installed.  See
 # <https://stackoverflow.com/q/592620>.  Some of these can probably be reasonably assumed
 # to be present, but err on the side of caution.
+
+detect_package_manager(){
+	case "$SHELL" in
+		*termux*) echo apt && return; ;;
+		*) ;;
+	esac
+	test -f /etc/debian_version && echo apt && return
+	test -f /etc/redhat-release && echo yum && return
+	test -f /etc/arch-release && echo pacman && return
+	test -f /etc/gentoo-release && echo emerge && return
+	test -f /etc/SuSE-release && echo zypp && return
+}
+
+try_to_install(){
+	package_manager="$(detect_package_manager)"
+	case "$package_manager" in
+		apt)
+			test -x "$(command -v sudo)" && sudo apt update || apt update
+			test -x "$(command -v sudo)" && sudo apt -y install "$1" || apt -y install "$1"
+		;;
+		yum)
+			test -x "$(command -v sudo)" && sudo yum update || yum update
+			test -x "$(command -v sudo)" && sudo yum -y install "$1" || yum -y install "$1"
+		;;
+		pacman)
+			pacman -Su
+			yes | pacman -S -y "$@"
+		;;
+		*)
+			echo "Program $1 unavailable. Please install it first" >&2
+			exit 127
+		;;
+	esac
+}
+
 for prog in awk cowsay figlet notify-send stty tput; do
    if ! hash "$prog" 2>/dev/null; then
-      printf 'muccadoro: %s: command not found\n' "$prog" >&2
-      exit 127
+      try_to_install "$prog"
    fi
 done
 


### PR DESCRIPTION
Added the `install.sh` script so any user can now do: `curl /web/path/to/installer.sh | sh` and have muccadoro installed. If user does not have curl, they can download and run the script. It will install curl at the end.
Also added installers inside the muccadoro so instead of outputing the error, it will attempt to install dependencies for the user.